### PR TITLE
Allow for whitespace after "time":

### DIFF
--- a/json_handler.go
+++ b/json_handler.go
@@ -42,7 +42,7 @@ func (h *JSONHandler) clear() {
 
 // TryHandle tells if this line was handled by this handler.
 func (h *JSONHandler) TryHandle(d []byte) bool {
-	if !bytes.Contains(d, []byte(`"time":"`)) {
+	if !bytes.Contains(d, []byte(`"time":`)) {
 		return false
 	}
 	err := h.UnmarshalJSON(d)


### PR DESCRIPTION
Previously JSONHandler.TryHandle was searching for "time":", including
the trailing quote. This breaks if there is whitespace after the colon,
as some JSON encoders produce. To fix this, check for the time field
after unmarshalling rather than searching the input string.
