### PR TITLE
Add --light-bg boolean flag

### DIFF
--- a/cmd/humanlog/main.go
+++ b/cmd/humanlog/main.go
@@ -68,6 +68,11 @@ func newApp() *cli.App {
 		Value: humanlog.DefaultOptions.TruncateLength,
 	}
 
+	lightBg := cli.BoolFlag{
+		Name:  "light-bg",
+		Usage: "use black as the base foreground color (for terminals with light backgrounds)",
+	}
+
 	app := cli.NewApp()
 	app.Author = "Antoine Grondin"
 	app.Email = "antoine@digitalocean.com"
@@ -75,7 +80,7 @@ func newApp() *cli.App {
 	app.Version = version
 	app.Usage = "reads structured logs from stdin, makes them pretty on stdout!"
 
-	app.Flags = []cli.Flag{skipFlag, keepFlag, sortLongest, skipUnchanged, truncates, truncateLength}
+	app.Flags = []cli.Flag{skipFlag, keepFlag, sortLongest, skipUnchanged, truncates, truncateLength, lightBg}
 
 	app.Action = func(c *cli.Context) error {
 
@@ -84,6 +89,7 @@ func newApp() *cli.App {
 		opts.SkipUnchanged = c.BoolT(skipUnchanged.Name)
 		opts.Truncates = c.BoolT(truncates.Name)
 		opts.TruncateLength = c.Int(truncateLength.Name)
+		opts.LightBg = c.BoolT(lightBg.Name)
 
 		switch {
 		case c.IsSet(skipFlag.Name) && c.IsSet(keepFlag.Name):

--- a/handler.go
+++ b/handler.go
@@ -15,6 +15,7 @@ var DefaultOptions = &HandlerOptions{
 	SortLongest:    true,
 	SkipUnchanged:  true,
 	Truncates:      true,
+	LightBg:        false,
 	TruncateLength: 15,
 	KeyRGB:         RGB{1, 108, 89},
 	ValRGB:         RGB{125, 125, 125},
@@ -30,6 +31,7 @@ type HandlerOptions struct {
 	SortLongest    bool
 	SkipUnchanged  bool
 	Truncates      bool
+	LightBg        bool
 	TruncateLength int
 	KeyRGB         RGB
 	ValRGB         RGB

--- a/json_handler.go
+++ b/json_handler.go
@@ -120,6 +120,8 @@ func (h *JSONHandler) Prettify(skipUnchanged bool) []byte {
 	var msg string
 	if h.Message == "" {
 		msg = rgbterm.FgString("<no msg>", 190, 190, 190)
+	} else if h.Opts.LightBg {
+		msg = rgbterm.FgString(h.Message, 0, 0, 0)
 	} else {
 		msg = rgbterm.FgString(h.Message, 255, 255, 255)
 	}

--- a/logrus_handler.go
+++ b/logrus_handler.go
@@ -79,6 +79,8 @@ func (h *LogrusHandler) Prettify(skipUnchanged bool) []byte {
 	var msg string
 	if h.Message == "" {
 		msg = rgbterm.FgString("<no msg>", 190, 190, 190)
+	} else if h.Opts.LightBg {
+		msg = rgbterm.FgString(h.Message, 0, 0, 0)
 	} else {
 		msg = rgbterm.FgString(h.Message, 255, 255, 255)
 	}


### PR DESCRIPTION
I use a light color scheme in my terminal, and I ran into the same issue that was reported in https://github.com/aybabtme/humanlog/issues/3. This PR is just one possible solution, but I'm certainly open to other ideas!

## New `--light-bg` flag

Defaults to false. When it's set to true, this flag inverts the base foreground color from white to black to make it possible (or easier) for users with light-colored terminal backgrounds to read the output.

I decided to keep this particular PR relatively small by focusing only on the default black/white, but this also opens up the possibility of swapping out [other colors](https://github.com/peterjmag/humanlog/blob/29a8d677acc3d70a970589f7a37be210edb9f7ed/logrus_handler.go#L91-L102) with darker counterparts in the future.

## New `--help` output

```
$ humanlog --help
NAME:
   humanlog - reads structured logs from stdin, makes them pretty on stdout!

USAGE:
   humanlogtest [global options] command [command options] [arguments...]

VERSION:
   devel

AUTHOR:
   Antoine Grondin <antoine@digitalocean.com>

COMMANDS:
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --skip value             keys to skip when parsing a log entry
   --keep value             keys to keep when parsing a log entry
   --sort-longest           sort by longest key after having sorted lexicographically
   --skip-unchanged         skip keys that have the same value than the previous entry
   --truncate               truncates values that are longer than --truncate-length
   --truncate-length value  truncate values that are longer than this length (default: 15)
   --light-bg               use black as the base foreground color (for terminals with light backgrounds)
   --help, -h               show help
   --version, -v            print the version
```

## Questions

- Is a CLI flag the right way to go here? If not, perhaps there's some way we can make this respond to `\033[40m` instead (as [@samv suggested](https://github.com/aybabtme/humanlog/issues/3#issue-169258991)).

- If we do go with a flag, is `--light-bg` clear enough? Or perhaps it should be something like `--dark-fg`?

## Screenshots

(Apologies for all the "redacted" stuff. I wasn't sure exactly what was considered sensitive in this particular private codebase, so I blurred out pretty much everything that wasn't generic. Happy to replace it with a public / open-source example if someone wants to suggest one!)

### Before

![humanlog-light-bg-before-02](https://cloud.githubusercontent.com/assets/352105/23704815/f7f5cb12-0406-11e7-9131-9b4dbc1586cd.png)

Note that since most of it's white text on a white background, it needs to be selected before you can read it.

### After

![humanlog-light-bg-after-03](https://cloud.githubusercontent.com/assets/352105/23705031/f259278e-0407-11e7-98b4-8bc8eaccbabc.png)