### PR TITLE
add time-format option

### DIFF
--- a/cmd/humanlog/main.go
+++ b/cmd/humanlog/main.go
@@ -75,6 +75,12 @@ func newApp() *cli.App {
 		Usage: "use black as the base foreground color (for terminals with light backgrounds)",
 	}
 
+	timeFormat := cli.StringFlag{
+		Name:  "time-format",
+		Usage: "output time format, see https://golang.org/pkg/time/ for details",
+		Value: humanlog.DefaultOptions.TimeFormat,
+	}
+
 	app := cli.NewApp()
 	app.Author = "Antoine Grondin"
 	app.Email = "antoine@digitalocean.com"
@@ -82,7 +88,7 @@ func newApp() *cli.App {
 	app.Version = version
 	app.Usage = "reads structured logs from stdin, makes them pretty on stdout!"
 
-	app.Flags = []cli.Flag{skipFlag, keepFlag, sortLongest, skipUnchanged, truncates, truncateLength, lightBg}
+	app.Flags = []cli.Flag{skipFlag, keepFlag, sortLongest, skipUnchanged, truncates, truncateLength, lightBg, timeFormat}
 
 	app.Action = func(c *cli.Context) error {
 
@@ -92,6 +98,7 @@ func newApp() *cli.App {
 		opts.Truncates = c.BoolT(truncates.Name)
 		opts.TruncateLength = c.Int(truncateLength.Name)
 		opts.LightBg = c.BoolT(lightBg.Name)
+		opts.TimeFormat = c.String(timeFormat.Name)
 
 		switch {
 		case c.IsSet(skipFlag.Name) && c.IsSet(keepFlag.Name):

--- a/handler.go
+++ b/handler.go
@@ -1,6 +1,8 @@
 package humanlog
 
 import (
+	"time"
+
 	"github.com/kr/logfmt"
 )
 
@@ -19,6 +21,7 @@ var DefaultOptions = &HandlerOptions{
 	TruncateLength: 15,
 	KeyRGB:         RGB{1, 108, 89},
 	ValRGB:         RGB{125, 125, 125},
+	TimeFormat:     time.Stamp,
 }
 
 type RGB struct{ R, G, B uint8 }
@@ -35,6 +38,7 @@ type HandlerOptions struct {
 	TruncateLength int
 	KeyRGB         RGB
 	ValRGB         RGB
+	TimeFormat     string
 }
 
 func (h *HandlerOptions) shouldShowKey(key string) bool {

--- a/json_handler.go
+++ b/json_handler.go
@@ -157,7 +157,7 @@ func (h *JSONHandler) Prettify(skipUnchanged bool) []byte {
 	}
 
 	_, _ = fmt.Fprintf(h.out, "%s |%s| %s\t %s",
-		rgbterm.FgString(h.Time.Format(time.Stamp), 99, 99, 99),
+		rgbterm.FgString(h.Time.Format(h.Opts.TimeFormat), 99, 99, 99),
 		level,
 		msg,
 		strings.Join(h.joinKVs(skipUnchanged, "="), "\t "),

--- a/logrus_handler.go
+++ b/logrus_handler.go
@@ -103,7 +103,7 @@ func (h *LogrusHandler) Prettify(skipUnchanged bool) []byte {
 	}
 
 	_, _ = fmt.Fprintf(h.out, "%s |%s| %s\t %s",
-		rgbterm.FgString(h.Time.Format(time.Stamp), 99, 99, 99),
+		rgbterm.FgString(h.Time.Format(h.Opts.TimeFormat), 99, 99, 99),
 		level,
 		msg,
 		strings.Join(h.joinKVs(skipUnchanged, "="), "\t "),


### PR DESCRIPTION
Added option to specify output time format:
```
GLOBAL OPTIONS:
   ...
   --time-format value      output time format, see https://golang.org/pkg/time/ for details (default: "Jan _2 15:04:05")
   ...
```