### PR TITLE
Better timestamp support

### DIFF
--- a/cmd/humanlog/main.go
+++ b/cmd/humanlog/main.go
@@ -6,8 +6,8 @@ import (
 	"os/signal"
 	"strings"
 
+	"github.com/aybabtme/humanlog"
 	"github.com/aybabtme/rgbterm"
-	"github.com/diag/humanlog"
 	"github.com/mattn/go-colorable"
 	"github.com/urfave/cli"
 )

--- a/cmd/humanlog/main.go
+++ b/cmd/humanlog/main.go
@@ -6,8 +6,8 @@ import (
 	"os/signal"
 	"strings"
 
-	"github.com/aybabtme/humanlog"
 	"github.com/aybabtme/rgbterm"
+	"github.com/diag/humanlog"
 	"github.com/mattn/go-colorable"
 	"github.com/urfave/cli"
 )

--- a/json_handler.go
+++ b/json_handler.go
@@ -61,26 +61,20 @@ func (h *JSONHandler) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	timeStr, ok := raw["time"].(string)
+	time, ok := raw["time"]
 	if ok {
 		delete(raw, "time")
 	} else {
-		timeStr, ok = raw["ts"].(string)
+		time, ok = raw["ts"]
 		if ok {
 			delete(raw, "ts")
 		}
 	}
 	if ok {
-		h.Time, ok = tryParseTime(timeStr)
+		h.Time, ok = tryParseTime(time)
 		if !ok {
-			return fmt.Errorf("field time is not a known timestamp: %v", timeStr)
+			return fmt.Errorf("field time is not a known timestamp: %v", time)
 		}
-	} else if i, iOk := raw["ts"].(int64); iOk {
-		h.Time = time.Unix(i, 0)
-		delete(raw, "ts")
-	} else if f, fOk := raw["ts"].(float64); fOk {
-		h.Time = time.Unix(int64(f), int64((f-float64(int64(f)))*1000000000))
-		delete(raw, "ts")
 	}
 	if h.Message, ok = raw["msg"].(string); ok {
 		delete(raw, "msg")

--- a/logrus_handler.go
+++ b/logrus_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -123,7 +124,12 @@ func (h *LogrusHandler) Prettify(skipUnchanged bool) []byte {
 func (h *LogrusHandler) setLevel(val []byte)   { h.Level = string(val) }
 func (h *LogrusHandler) setMessage(val []byte) { h.Message = string(val) }
 func (h *LogrusHandler) setTime(val []byte) (parsed bool) {
-	h.Time, parsed = tryParseTime(string(val))
+	valStr := string(val)
+	if valFloat, err := strconv.ParseFloat(valStr, 64); err == nil {
+		h.Time, parsed = tryParseTime(valFloat)
+	} else {
+		h.Time, parsed = tryParseTime(string(val))
+	}
 	return
 }
 


### PR DESCRIPTION
For our needs we wanted the field named `time` to work for both text timestamps as well as numeric timestamps. This adds support for second, millisecond and nanosecond timestamps as well.