### PR TITLE
handle light/dark background terminals better

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -22,18 +22,21 @@ var DefaultOptions = &HandlerOptions{
 	TruncateLength: 15,
 	TimeFormat:     time.Stamp,
 
-	KeyColor:          color.New(color.FgGreen),
-	ValColor:          color.New(color.FgHiWhite),
-	TimeColor:         color.New(color.FgBlack),
-	MsgColor:          color.New(color.FgBlack),
-	MsgAbsentColor:    color.New(color.FgWhite),
-	DebugLevelColor:   color.New(color.FgMagenta),
-	InfoLevelColor:    color.New(color.FgCyan),
-	WarnLevelColor:    color.New(color.FgYellow),
-	ErrorLevelColor:   color.New(color.FgRed),
-	PanicLevelColor:   color.New(color.BgRed),
-	FatalLevelColor:   color.New(color.BgHiRed, color.FgHiWhite),
-	UnknownLevelColor: color.New(color.FgMagenta),
+	KeyColor:              color.New(color.FgGreen),
+	ValColor:              color.New(color.FgHiWhite),
+	TimeLightBgColor:      color.New(color.FgBlack),
+	TimeDarkBgColor:       color.New(color.FgWhite),
+	MsgLightBgColor:       color.New(color.FgBlack),
+	MsgAbsentLightBgColor: color.New(color.FgHiBlack),
+	MsgDarkBgColor:        color.New(color.FgHiWhite),
+	MsgAbsentDarkBgColor:  color.New(color.FgWhite),
+	DebugLevelColor:       color.New(color.FgMagenta),
+	InfoLevelColor:        color.New(color.FgCyan),
+	WarnLevelColor:        color.New(color.FgYellow),
+	ErrorLevelColor:       color.New(color.FgRed),
+	PanicLevelColor:       color.New(color.BgRed),
+	FatalLevelColor:       color.New(color.BgHiRed, color.FgHiWhite),
+	UnknownLevelColor:     color.New(color.FgMagenta),
 }
 
 type HandlerOptions struct {
@@ -46,18 +49,21 @@ type HandlerOptions struct {
 	TruncateLength int
 	TimeFormat     string
 
-	KeyColor          *color.Color
-	ValColor          *color.Color
-	TimeColor         *color.Color
-	MsgColor          *color.Color
-	MsgAbsentColor    *color.Color
-	DebugLevelColor   *color.Color
-	InfoLevelColor    *color.Color
-	WarnLevelColor    *color.Color
-	ErrorLevelColor   *color.Color
-	PanicLevelColor   *color.Color
-	FatalLevelColor   *color.Color
-	UnknownLevelColor *color.Color
+	KeyColor              *color.Color
+	ValColor              *color.Color
+	TimeLightBgColor      *color.Color
+	TimeDarkBgColor       *color.Color
+	MsgLightBgColor       *color.Color
+	MsgAbsentLightBgColor *color.Color
+	MsgDarkBgColor        *color.Color
+	MsgAbsentDarkBgColor  *color.Color
+	DebugLevelColor       *color.Color
+	InfoLevelColor        *color.Color
+	WarnLevelColor        *color.Color
+	ErrorLevelColor       *color.Color
+	PanicLevelColor       *color.Color
+	FatalLevelColor       *color.Color
+	UnknownLevelColor     *color.Color
 }
 
 func (h *HandlerOptions) shouldShowKey(key string) bool {

--- a/json_handler.go
+++ b/json_handler.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 // JSONHandler can handle logs emmited by logrus.TextFormatter loggers.
@@ -125,11 +127,25 @@ func (h *JSONHandler) Prettify(skipUnchanged bool) []byte {
 		h.out = tabwriter.NewWriter(h.buf, 0, 1, 0, '\t', 0)
 	}
 
+	var (
+		msgColor       *color.Color
+		msgAbsentColor *color.Color
+	)
+	if h.Opts.LightBg {
+		msgColor = h.Opts.MsgLightBgColor
+		msgAbsentColor = h.Opts.MsgAbsentLightBgColor
+	} else {
+		msgColor = h.Opts.MsgDarkBgColor
+		msgAbsentColor = h.Opts.MsgAbsentDarkBgColor
+	}
+	msgColor = color.New(color.FgHiWhite)
+	msgAbsentColor = color.New(color.FgHiWhite)
+
 	var msg string
 	if h.Message == "" {
-		msg = h.Opts.MsgAbsentColor.Sprint("<no msg>")
+		msg = msgAbsentColor.Sprint("<no msg>")
 	} else {
-		msg = h.Opts.MsgColor.Sprint(h.Message)
+		msg = msgColor.Sprint(h.Message)
 	}
 
 	lvl := strings.ToUpper(h.Level)[:imin(4, len(h.Level))]
@@ -149,8 +165,14 @@ func (h *JSONHandler) Prettify(skipUnchanged bool) []byte {
 		level = h.Opts.UnknownLevelColor.Sprint(lvl)
 	}
 
+	var timeColor *color.Color
+	if h.Opts.LightBg {
+		timeColor = h.Opts.TimeLightBgColor
+	} else {
+		timeColor = h.Opts.TimeDarkBgColor
+	}
 	_, _ = fmt.Fprintf(h.out, "%s |%s| %s\t %s",
-		h.Opts.TimeColor.Sprint(h.Time.Format(h.Opts.TimeFormat)),
+		timeColor.Sprint(h.Time.Format(h.Opts.TimeFormat)),
 		level,
 		msg,
 		strings.Join(h.joinKVs(skipUnchanged, "="), "\t "),

--- a/logrus_handler.go
+++ b/logrus_handler.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 // LogrusHandler can handle logs emmited by logrus.TextFormatter loggers.
@@ -81,11 +83,23 @@ func (h *LogrusHandler) Prettify(skipUnchanged bool) []byte {
 		h.out = tabwriter.NewWriter(h.buf, 0, 1, 0, '\t', 0)
 	}
 
+	var (
+		msgColor       *color.Color
+		msgAbsentColor *color.Color
+	)
+	if h.Opts.LightBg {
+		msgColor = h.Opts.MsgLightBgColor
+		msgAbsentColor = h.Opts.MsgAbsentLightBgColor
+	} else {
+		msgColor = h.Opts.MsgDarkBgColor
+		msgAbsentColor = h.Opts.MsgAbsentDarkBgColor
+	}
+
 	var msg string
 	if h.Message == "" {
-		msg = h.Opts.MsgAbsentColor.Sprint("<no msg>")
+		msg = msgAbsentColor.Sprint("<no msg>")
 	} else {
-		msg = h.Opts.MsgColor.Sprint(h.Message)
+		msg = msgColor.Sprint(h.Message)
 	}
 
 	lvl := strings.ToUpper(h.Level)[:imin(4, len(h.Level))]
@@ -105,8 +119,14 @@ func (h *LogrusHandler) Prettify(skipUnchanged bool) []byte {
 		level = h.Opts.UnknownLevelColor.Sprint(lvl)
 	}
 
+	var timeColor *color.Color
+	if h.Opts.LightBg {
+		timeColor = h.Opts.TimeLightBgColor
+	} else {
+		timeColor = h.Opts.TimeDarkBgColor
+	}
 	_, _ = fmt.Fprintf(h.out, "%s |%s| %s\t %s",
-		h.Opts.TimeColor.Sprint(h.Time.Format(h.Opts.TimeFormat)),
+		timeColor.Sprint(h.Time.Format(h.Opts.TimeFormat)),
 		level,
 		msg,
 		strings.Join(h.joinKVs(skipUnchanged, "="), "\t "),


### PR DESCRIPTION
Currently the colors for time and msg fields don’t properly handle dark bg terminals resulting in dark on dark colors. If your terminal is configured to have a black color that is similar to your background color these fields become unreadable.

This PR should help make these fields more readable.