### PR TITLE
Add docker-compose handler

### DIFF
--- a/docker_compose_handler.go
+++ b/docker_compose_handler.go
@@ -5,6 +5,12 @@ import (
 )
 
 // dcLogsPrefixRe parses out a prefix like 'web_1 | ' from docker-compose
+// The regex exists of five parts:
+// 1. An optional color terminal escape sequence
+// 2. The name of the service
+// 3. Any number of spaces, and a pipe symbol
+// 4. An optional color reset escape sequence
+// 5. The rest of the line
 var dcLogsPrefixRe = regexp.MustCompile("^(?:\x1b\\[\\d+m)?(?P<service_name>[a-zA-Z0-9._-]+)\\s+\\|(?:\x1b\\[0m)? (?P<rest_of_line>.*)$")
 
 type handler interface {

--- a/docker_compose_handler.go
+++ b/docker_compose_handler.go
@@ -5,7 +5,7 @@ import (
 )
 
 // dcLogsPrefixRe parses out a prefix like 'web_1 | ' from docker-compose
-var dcLogsPrefixRe = regexp.MustCompile("^(?:\x1b\\[\\d+m)?([a-zA-Z0-9._-]+)\\s+\\|(?:\x1b\\[0m)? (.*)$")
+var dcLogsPrefixRe = regexp.MustCompile("^(?:\x1b\\[\\d+m)?(?P<service_name>[a-zA-Z0-9._-]+)\\s+\\|(?:\x1b\\[0m)? (?P<rest_of_line>.*)$")
 
 type handler interface {
 	TryHandle([]byte) bool

--- a/docker_compose_handler.go
+++ b/docker_compose_handler.go
@@ -1,0 +1,23 @@
+package humanlog
+
+import (
+	"regexp"
+)
+
+// dcLogsPrefixRe parses out a prefix like 'web_1 | ' from docker-compose
+var dcLogsPrefixRe = regexp.MustCompile("^(?:\x1b\\[\\d+m)?([a-zA-Z0-9._-]+)\\s+\\|(?:\x1b\\[0m)? (.*)$")
+
+type handler interface {
+	TryHandle([]byte) bool
+	setField(key, val []byte)
+}
+
+func tryDockerComposePrefix(d []byte, nextHandler handler) bool {
+	if matches := dcLogsPrefixRe.FindSubmatch(d); matches != nil {
+		if nextHandler.TryHandle(matches[2]) {
+			nextHandler.setField([]byte(`service`), matches[1])
+			return true
+		}
+	}
+	return false
+}

--- a/json_handler.go
+++ b/json_handler.go
@@ -131,6 +131,12 @@ func (h *JSONHandler) UnmarshalJSON(data []byte) bool {
 
 	return true
 }
+func (h *JSONHandler) setField(key, val []byte) {
+	if h.Fields == nil {
+		h.Fields = make(map[string]string)
+	}
+	h.Fields[string(key)] = string(val)
+}
 
 // Prettify the output in a logrus like fashion.
 func (h *JSONHandler) Prettify(skipUnchanged bool) []byte {

--- a/scanner.go
+++ b/scanner.go
@@ -42,6 +42,14 @@ func Scanner(src io.Reader, dst io.Writer, opts *HandlerOptions) error {
 			dst.Write(logfmtEntry.Prettify(opts.SkipUnchanged && lastLogfmt))
 			lastLogfmt = true
 
+		case tryDockerComposePrefix(lineData, &jsonEntry):
+			dst.Write(jsonEntry.Prettify(opts.SkipUnchanged && lastJSON))
+			lastJSON = true
+
+		case tryDockerComposePrefix(lineData, &logfmtEntry):
+			dst.Write(logfmtEntry.Prettify(opts.SkipUnchanged && lastLogfmt))
+			lastLogfmt = true
+
 		default:
 			lastLogfmt = false
 			lastJSON = false


### PR DESCRIPTION
This handler filters out the docker-compose prefix, and then passes on the rest of the line to another handler.

This way you can just do `docker-compose logs 2>&1 | humanlog` instead of messing around with filters to make the logs readable.