### PR TITLE
accept stackdriver 'severity' tag as level

### DIFF
--- a/json_handler.go
+++ b/json_handler.go
@@ -45,7 +45,7 @@ var supportedTimeFields = []string{"time", "ts", "@timestamp", "timestamp"}
 var supportedMessageFields = []string{"message", "msg"}
 
 // supportedLevelFields enumarates supported level field names
-var supportedLevelFields = []string{"level", "lvl", "loglevel"}
+var supportedLevelFields = []string{"level", "lvl", "loglevel", "severity"}
 
 func (h *JSONHandler) clear() {
 	h.Level = ""


### PR DESCRIPTION
Stackdriver logs have a severity tag which is the log level equivalent (https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry). Adds support for it here, allowing humanlog to colorize them.